### PR TITLE
Video bitrate

### DIFF
--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -247,7 +247,7 @@ func (enc *VideoEncoder) Setup() (err error) {
 	// over which the bitrate is controlled. By setting size = max * 2, we give
 	// a window of 2 seconds to mitigate the effects of bitrate peaks on the 
 	// overall quality
-	ff.codecCtx.rc_max_rate		= C.int64_t(enc.Bitrate * 1000)
+	ff.codecCtx.rc_max_rate		= C.int64_t(enc.Bitrate)
 	ff.codecCtx.rc_buffer_size	= C.int(ff.codecCtx.rc_max_rate * 2)
 
 	if C.avcodec_open2(ff.codecCtx, ff.codec, &ff.options) != 0 {

--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -339,10 +339,11 @@ func (enc *VideoEncoder) encodeOne(img *VideoFrame) (gotpkt bool, pkt []byte, er
 		fmt.Println("ffmpeg: no pkt !")
 	}
 
-	if ok, kbps := enc.bm.Measure(len(avpkt.Data)); ok {
-		fmt.Println("Encoded video bitrate (kbps):", kbps)
+	if debug {
+		if ok, kbps := enc.bm.Measure(len(avpkt.Data)); ok {
+			fmt.Println("Encoded video bitrate (kbps):", kbps)
+		}
 	}
-
 	return gotpkt, avpkt.Data, err
 }
 

--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -226,6 +226,9 @@ func (enc *VideoEncoder) Setup() (err error) {
 	}
 
 
+	if err = enc.SetOption("preset", "ultrafast"); err != nil {
+		return
+	}
 	if err = enc.SetOption("crf", "23"); err != nil {
 		return
 	}

--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -289,8 +289,7 @@ func (enc *VideoEncoder) encodeOne(img *VideoFrame) (gotpkt bool, pkt []byte, er
 	ff.frame.sample_aspect_ratio.num = 0 // TODO
 	ff.frame.sample_aspect_ratio.den = 1
 
-	// Increase pts and convert in 90k: pts * 90000 / fps
-	ff.frame.pts = C.int64_t( int(enc.pts) * enc.fpsDen * 90000 / enc.fpsNum)
+	ff.frame.pts = C.longlong(enc.pts)
 	enc.pts++
 
 	cerr := C.avcodec_encode_video2(ff.codecCtx, &cpkt, ff.frame, &cgotpkt)


### PR DESCRIPTION
# PR Type

- [ ] Feature
- [x] Bug fix
- [ ] Docs

## Description

Fix the video bitrate not respecting the target
- use pts in the form "0, 1, 2, 3..." instead of using 90kHz pts
- use CRF + VBV to get a good "capped VBR" behaviour

## Notes for your reviewer

I also set the enc preset to 'ultrafast' to save CPU power, I will test quality at a wide range of bitrate to see if it is an acceptable setting

