### PR TITLE
[fpsconv] fix framerate increasing

### DIFF
--- a/av/av.go
+++ b/av/av.go
@@ -398,6 +398,17 @@ const (
 	InterlacedBFF // Bottom Field First
 )
 
+func (s ScanningMode) String() string {
+	switch s {
+	case Progressive:
+		return "Progressive"
+	case InterlacedTFF:
+		return "InterlacedTFF"
+	case InterlacedBFF:
+		return "InterlacedBFF"
+	}
+	return "Unknown scanning mode"
+}
 
 type BitrateMeasure struct {
 	lastPrint time.Time
@@ -425,4 +436,8 @@ func (bm *BitrateMeasure) Measure(size int) (measureReady bool, bitrateKbps int)
 		}
 	}
 	return false, 0
+}
+
+func (bm BitrateMeasure) String() string {
+	return fmt.Sprintf("%d kbps", bm.AvgKbps)
 }

--- a/av/transcode/transcode.go
+++ b/av/transcode/transcode.go
@@ -103,7 +103,7 @@ func (self *tStream) audioDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 	}
 
 	if dur, err = self.adecodec.PacketDuration(inpkt.Data); err != nil {
-		err = fmt.Errorf("transcode: PacketDuration() failed for input stream #%d", inpkt.Idx)
+		err = fmt.Errorf("transcode: PacketDuration() failed for input audio stream #%d", inpkt.Idx)
 		return
 	}
 
@@ -118,7 +118,7 @@ func (self *tStream) audioDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 	}
 	for _, _outpkt := range _outpkts {
 		if dur, err = self.aencodec.PacketDuration(_outpkt); err != nil {
-			err = fmt.Errorf("transcode: PacketDuration() failed for output stream #%d", inpkt.Idx)
+			err = fmt.Errorf("transcode: PacketDuration() failed for output audio stream #%d", inpkt.Idx)
 			return
 		}
 		outpkt := av.Packet{Idx: inpkt.Idx, Data: _outpkt}
@@ -142,7 +142,7 @@ func (self *tStream) videoDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 	}
 
 	if dur, err = self.vdecodec.PacketDuration(inpkt.Data); err != nil {
-		err = fmt.Errorf("transcode: PacketDuration() failed for input stream #%d", inpkt.Idx)
+		err = fmt.Errorf("transcode: PacketDuration() failed for input video stream #%d", inpkt.Idx)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (self *tStream) videoDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 			self.vencodec = codecData.(av.VideoCodecData)
 		}
 		if dur, err = self.vencodec.PacketDuration(_outpkt); err != nil {
-			err = fmt.Errorf("transcode: PacketDuration() failed for output stream #%d", inpkt.Idx)
+			err = fmt.Errorf("transcode: PacketDuration() failed for output video stream #%d", inpkt.Idx)
 			return
 		}
 		outpkt := av.Packet{Idx: inpkt.Idx, Data: _outpkt}


### PR DESCRIPTION
# PR Type

- [ ] Feature
- [x] Bug fix
- [ ] Docs

## Description

Freeing output images caused crashes when increasing the framerate (for example 20 fps to 25 fps)
This PR reworks the free mechanism to properly manage increased fps.

## Notes for your reviewer

I also improved debug traces
