### PR TITLE
[avutil] add method to copy a stream from the first video keyframe

### DIFF
--- a/av/transcode/transcode.go
+++ b/av/transcode/transcode.go
@@ -151,7 +151,7 @@ func (self *tStream) videoDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 	}
 	self.timeline.Push(inpkt.Time, dur)
 
-	var _outpkts [][]byte
+	var _outpkts []av.Packet
 	if _outpkts, err = self.venc.Encode(frame); err != nil {
 		return
 	}
@@ -166,11 +166,12 @@ func (self *tStream) videoDecodeAndEncode(inpkt av.Packet) (outpkts []av.Packet,
 			}
 			self.vencodec = codecData.(av.VideoCodecData)
 		}
-		if dur, err = self.vencodec.PacketDuration(_outpkt); err != nil {
+		if dur, err = self.vencodec.PacketDuration(_outpkt.Data); err != nil {
 			err = fmt.Errorf("transcode: PacketDuration() failed for output video stream #%d", inpkt.Idx)
 			return
 		}
-		outpkt := av.Packet{Idx: inpkt.Idx, Data: _outpkt}
+		// TODO probably not needed now that _outpkt is an av.Packet 
+		outpkt := av.Packet{IsKeyFrame: _outpkt.IsKeyFrame, Idx: inpkt.Idx, Data: _outpkt.Data}
 		outpkt.Time = self.timeline.Pop(dur)
 
 		if Debug {

--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -497,7 +497,7 @@ func (enc *VideoEncoder) CodecData() (codec av.VideoCodecData, err error) {
 	return
 }
 
-func (enc *VideoEncoder) encodeOne(img *VideoFrame) (gotpkt bool, pkt []byte, err error) {
+func (enc *VideoEncoder) encodeOne(img *VideoFrame) (gotpkt bool, pkt av.Packet, err error) {
 	if err = enc.prepare(); err != nil {
 		return
 	}
@@ -561,7 +561,7 @@ func (enc *VideoEncoder) encodeOne(img *VideoFrame) (gotpkt bool, pkt []byte, er
 			fmt.Println("Encoded video bitrate (kbps):", kbps)
 		}
 	}
-	return gotpkt, avpkt.Data, err
+	return gotpkt, avpkt, err
 }
 
 
@@ -604,9 +604,9 @@ func (self *VideoEncoder) convertFramerate(img *VideoFrame) (out []*VideoFrame, 
 }
 
 
-func (enc *VideoEncoder) Encode(img *VideoFrame) (pkts [][]byte, err error) {
+func (enc *VideoEncoder) Encode(img *VideoFrame) (pkts []av.Packet, err error) {
 	var gotpkt bool
-	var pkt []byte
+	var pkt av.Packet
 	var frames []*VideoFrame
 
 	// If the input framerate and desired encoding framerate differ, convert using FramerateConverter

--- a/cgo/ffmpeg/video.go
+++ b/cgo/ffmpeg/video.go
@@ -250,7 +250,6 @@ func (self *FramerateConverter) ConvertFramerate(in *VideoFrame) (out []*VideoFr
 	if self.graph == nil {
 		err = self.ConfigureVideoFilters()
 		if err != nil {
-			fmt.Println("ConfigureVideoFilters failed:", err)
 			return
 		}
 	}


### PR DESCRIPTION
# PR Type

- [x] Feature
- [ ] Bug fix
- [ ] Docs

## Description

Add CopyFileFromKeyframe() to copy a stream from the first video keyframe (the audio stream is copied straight away.
This allows multiple calls to CopyFileFromKeyframe() with the same source, at different moments in time, without introducing A/V desynchronisation.

## Notes for your reviewer

I think this works best with streams with a low Gop (1 or 2 seconds), I have not tested very long gops (but long gops are not desirable for streaming anyway).