### PR TITLE
Fix not closing transcoder in example

### DIFF
--- a/examples/video_transcoder/main.go
+++ b/examples/video_transcoder/main.go
@@ -118,6 +118,7 @@ func main() {
 		delete(channels, conn.URL.Path)
 		l.Unlock()
 		ch.que.Close()
+		trans.Close()
 	}
 
 	http.HandleFunc("/file", func(w http.ResponseWriter, r *http.Request) {
@@ -142,6 +143,7 @@ func main() {
 		muxer := flv.NewMuxerWriteFlusher(writeFlusher{httpflusher: flusher, Writer: w})
 		avutil.CopyFile(muxer, trans)
 		file.Close()
+		trans.Close()
 	})
 
 	go http.ListenAndServe(":8089", nil)

--- a/examples/video_transcoder/main.go
+++ b/examples/video_transcoder/main.go
@@ -141,7 +141,10 @@ func main() {
 		}
 
 		muxer := flv.NewMuxerWriteFlusher(writeFlusher{httpflusher: flusher, Writer: w})
-		avutil.CopyFile(muxer, trans)
+		err := avutil.CopyFile(muxer, trans)
+		if err != nil {
+			fmt.Println("Error in CopyFile():", err)
+		}
 		file.Close()
 		trans.Close()
 	})


### PR DESCRIPTION
# PR Type

- [ ] Feature
- [x] Bug fix
- [ ] Docs

## Description

Close the transcoder in video_transcoder example.
Also added printing errors from CopyFile()
