### PR TITLE
Bypass parsing C1 during RTMP handshake.

### DIFF
--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -1608,8 +1608,9 @@ func (self *Conn) handshakeServer() (err error) {
 		var ok bool
 		var digest []byte
 		if ok, digest = hsParse1(C1, hsClientPartialKey, hsServerFullKey); !ok {
-			err = fmt.Errorf("rtmp: handshake server: C1 invalid")
-			return
+			fmt.Println("rtmp: handshake server: C1 invalid")
+			// err = fmt.Errorf("rtmp: handshake server: C1 invalid")
+			// return
 		}
 		hsCreate01(S0S1, srvtime, srvver, hsServerPartialKey)
 		hsCreate2(S2, digest)

--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -1605,13 +1605,9 @@ func (self *Conn) handshakeServer() (err error) {
 	cliver := pio.U32BE(C1[4:8])
 
 	if cliver != 0 {
-		var ok bool
 		var digest []byte
-		if ok, digest = hsParse1(C1, hsClientPartialKey, hsServerFullKey); !ok {
-			fmt.Println("rtmp: handshake server: C1 invalid")
-			// err = fmt.Errorf("rtmp: handshake server: C1 invalid")
-			// return
-		}
+		// FIXME check if hsParse1 returns ok. Ignored atm because it seems buggy
+		_, digest = hsParse1(C1, hsClientPartialKey, hsServerFullKey)
 		hsCreate01(S0S1, srvtime, srvver, hsServerPartialKey)
 		hsCreate2(S2, digest)
 	} else {


### PR DESCRIPTION
# PR Type

- [ ] Feature
- [x] Bug fix
- [ ] Docs

## Description

Bypass parsing C1 during RTMP handshake. This fixes using Larix Broadcaster for Android as an RTMP client.
